### PR TITLE
タスクの登録・編集フォーム機能をモーダル形式で実装

### DIFF
--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::TasksController < Api::V1::BaseController
-  before_action :set_task, only: [:show, :destroy]
+  before_action :set_task, only: [:show, :update, :destroy]
 
   # GET /api/v1/tasks
   def index
@@ -18,6 +18,15 @@ class Api::V1::TasksController < Api::V1::BaseController
 
     if @task.save
       render json: @task, status: :created
+    else
+      render json: { errors: @task.errors }, status: :unprocessable_entity
+    end
+  end
+
+  # PUT /api/v1/tasks/:id
+  def update
+    if @task.update(task_params)
+      render json: @task
     else
       render json: { errors: @task.errors }, status: :unprocessable_entity
     end

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -10,6 +10,7 @@ class Task < ApplicationRecord
   enum :status, { todo: 'todo', in_progress: 'in_progress', completed: 'completed', cancelled: 'cancelled' }
 
   validates :title, presence: true
+  validates :description, length: { maximum: 200 }
   validates :duration, presence: true, numericality: { greater_than: 0 }
   validates :energy_required, inclusion: { in: 1..10 }
   validates :importance, inclusion: { in: 1..5 }

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   # API routes
   namespace :api do
     namespace :v1 do
-      resources :tasks, only: [:index, :show, :create, :destroy]
+      resources :tasks, only: [:index, :show, :create, :update, :destroy]
     end
   end
 

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -45,6 +45,29 @@ RSpec.describe Task, type: :model do
       expect(task).not_to be_valid
       expect(task.errors[:importance]).to include("is not included in the list")
     end
+
+    it "is valid with description up to 200 characters" do
+      description = "a" * 200
+      task = Task.new(title: "Test Task", duration: 60, description: description)
+      expect(task).to be_valid
+    end
+
+    it "is invalid with description over 200 characters" do
+      description = "a" * 201
+      task = Task.new(title: "Test Task", duration: 60, description: description)
+      expect(task).not_to be_valid
+      expect(task.errors[:description]).to include("is too long (maximum is 200 characters)")
+    end
+
+    it "is valid with empty description" do
+      task = Task.new(title: "Test Task", duration: 60, description: "")
+      expect(task).to be_valid
+    end
+
+    it "is valid with nil description" do
+      task = Task.new(title: "Test Task", duration: 60, description: nil)
+      expect(task).to be_valid
+    end
   end
 
   describe "dependencies" do
@@ -54,7 +77,7 @@ RSpec.describe Task, type: :model do
         duration: 60,
         dependencies: [1, 2, 3]
       )
-      
+
       expect(task.dependencies).to eq([1, 2, 3])
       expect(task.dependencies).to be_a(Array)
     end
@@ -68,7 +91,7 @@ RSpec.describe Task, type: :model do
       task = Task.create!(title: "Test Task", duration: 60, dependencies: [])
       task.dependencies = [4, 5]
       task.save!
-      
+
       task.reload
       expect(task.dependencies).to eq([4, 5])
     end

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe "Api::V1::Tasks", type: :request do
       {
         task: {
           title: "",
+          description: "a" * 201, # 201文字で文字数制限違反
           duration: -1,
           energy_required: 15
         }
@@ -173,6 +174,7 @@ RSpec.describe "Api::V1::Tasks", type: :request do
       {
         task: {
           title: "",
+          description: "a" * 201, # 201文字で文字数制限違反
           duration: -1,
           energy_required: 15
         }

--- a/backend/spec/requests/api/v1/tasks_spec.rb
+++ b/backend/spec/requests/api/v1/tasks_spec.rb
@@ -138,6 +138,110 @@ RSpec.describe "Api::V1::Tasks", type: :request do
     end
   end
 
+  describe "PUT /api/v1/tasks/:id" do
+    let!(:task) do
+      Task.create!(
+        title: "Original Task",
+        description: "Original Description",
+        duration: 60,
+        energy_required: 5,
+        importance: 3,
+        urgency: 4,
+        ease: 2,
+        status: "todo",
+        dependencies: []
+      )
+    end
+
+    let(:valid_update_attributes) do
+      {
+        task: {
+          title: "Updated Task",
+          description: "Updated Description",
+          duration: 120,
+          energy_required: 7,
+          importance: 5,
+          urgency: 3,
+          ease: 4,
+          status: "completed",
+          dependencies: [1, 2]
+        }
+      }
+    end
+
+    let(:invalid_update_attributes) do
+      {
+        task: {
+          title: "",
+          duration: -1,
+          energy_required: 15
+        }
+      }
+    end
+
+    context "when task exists" do
+      context "with valid parameters" do
+        it "updates the task" do
+          put "/api/v1/tasks/#{task.id}", params: valid_update_attributes, as: :json
+
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          expect(json_response["title"]).to eq("Updated Task")
+          expect(json_response["description"]).to eq("Updated Description")
+          expect(json_response["duration"]).to eq(120)
+          expect(json_response["status"]).to eq("completed")
+          expect(json_response["dependencies"]).to eq([1, 2])
+
+          # データベースでも更新されていることを確認
+          task.reload
+          expect(task.title).to eq("Updated Task")
+          expect(task.status).to eq("completed")
+        end
+
+        it "updates only specified fields" do
+          partial_update = {
+            task: {
+              title: "Partially Updated Task",
+              status: "in_progress"
+            }
+          }
+
+          put "/api/v1/tasks/#{task.id}", params: partial_update, as: :json
+
+          expect(response).to have_http_status(:ok)
+          json_response = JSON.parse(response.body)
+          expect(json_response["title"]).to eq("Partially Updated Task")
+          expect(json_response["status"]).to eq("in_progress")
+          expect(json_response["description"]).to eq("Original Description") # 元の値が保持される
+        end
+      end
+
+      context "with invalid parameters" do
+        it "returns validation errors" do
+          put "/api/v1/tasks/#{task.id}", params: invalid_update_attributes, as: :json
+
+          expect(response).to have_http_status(:unprocessable_entity)
+          json_response = JSON.parse(response.body)
+          expect(json_response["errors"]).to be_present
+
+          # データベースは更新されていないことを確認
+          task.reload
+          expect(task.title).to eq("Original Task")
+        end
+      end
+    end
+
+    context "when task does not exist" do
+      it "returns 404" do
+        put "/api/v1/tasks/999999", params: valid_update_attributes, as: :json
+
+        expect(response).to have_http_status(:not_found)
+        json_response = JSON.parse(response.body)
+        expect(json_response["error"]).to eq("Task not found")
+      end
+    end
+  end
+
   describe "DELETE /api/v1/tasks/:id" do
     let!(:task) do
       Task.create!(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hot-toast": "^2.5.2",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -2215,8 +2216,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3370,6 +3370,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -4857,6 +4865,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.5.2",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -340,8 +340,13 @@ body {
 
 .search-container {
   position: relative;
-  max-width: 400px;
   width: 100%;
+}
+
+@media (min-width: 767px) {
+  .search-container {
+    max-width: 400px;
+  }
 }
 
 .search-input {
@@ -545,7 +550,7 @@ body {
 
 .task-cards-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   gap: 1.5rem;
   grid-auto-rows: 1fr; /* 各行の高さを均一にする */
   padding-bottom: 2rem; /* 最後のカードの下に余白 */
@@ -686,6 +691,7 @@ body {
   gap: 0.5rem;
   margin-bottom: 0.5rem;
   font-size: 0.85rem;
+  white-space: nowrap;
 }
 
 .task-stat-icon {
@@ -698,6 +704,7 @@ body {
 .task-stat-value {
   color: white;
   background-color: var(--primary);
+  white-space: nowrap;
 }
 
 .task-progress {
@@ -930,6 +937,7 @@ body {
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
 /* タスクカードの高さを統一するための追加スタイル */
 .space-y-3 {
   display: flex;
@@ -942,6 +950,7 @@ body {
 .task-stat:last-child {
   margin-top: auto;
 }
+
 /* 優先度別ホバー効果 */
 .task-card.priority-low:hover {
   border-color: var(--priority-low);
@@ -1005,6 +1014,7 @@ body {
 .task-card:hover .priority-stars .star-filled {
   filter: brightness(1.3) drop-shadow(0 0 4px rgba(255, 215, 0, 0.6));
 }
+
 /* 画面サイズが狭いときのタスク詳細表示調整 */
 @media (max-width: 640px) {
   .task-stat {
@@ -1022,6 +1032,7 @@ body {
     margin-right: 4px;
   }
 }
+
 /* グリッドレイアウトの調整 */
 @media (min-width: 640px) {
   .task-card-content .grid {
@@ -1032,5 +1043,328 @@ body {
 @media (min-width: 767px) {
   .task-card-content .grid {
     column-gap: 2.5rem;
+  }
+}
+
+/* ===== モーダル ===== */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+}
+
+.modal-content {
+  background: var(--card);
+  border-radius: 12px;
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.4), 0 10px 25px rgba(139, 69, 19, 0.2),
+    inset 0 2px 0 rgba(245, 230, 211, 0.3);
+  border: 2px solid var(--border);
+  max-width: 600px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 1.5rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+}
+
+.modal-title {
+  font-family: "Cinzel", "Georgia", serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--primary);
+  margin: 0;
+}
+
+.modal-close-button {
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  padding: 0.5rem;
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
+
+.modal-close-button:hover {
+  background-color: rgba(139, 69, 19, 0.1);
+  color: var(--primary);
+}
+
+.modal-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+/* ===== フォーム ===== */
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.form-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--primary);
+  font-size: 0.9rem;
+  font-family: "Cinzel", "Georgia", serif;
+}
+
+.form-label.required::after {
+  content: "*";
+  color: #dc2626;
+  margin-right: 0.25rem;
+}
+
+.form-input,
+.form-textarea,
+.form-select {
+  padding: 0.75rem;
+  border: 2px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+  color: var(--card-foreground);
+  font-size: 0.9rem;
+  transition: all 0.2s ease;
+}
+
+.form-input:focus,
+.form-textarea:focus,
+.form-select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(139, 69, 19, 0.1);
+}
+
+.form-input-error {
+  border-color: #dc2626;
+}
+
+.form-input-error:focus {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.1);
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.form-error {
+  color: #dc2626;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border);
+}
+
+.form-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 2px solid transparent;
+}
+
+.form-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.form-button-primary {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-color: var(--primary);
+}
+
+.form-button-primary:hover:not(:disabled) {
+  background: var(--secondary);
+  border-color: var(--secondary);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(139, 69, 19, 0.3);
+}
+
+.form-button-secondary {
+  background: transparent;
+  color: var(--muted-foreground);
+  border-color: var(--border);
+}
+
+.form-button-secondary:hover:not(:disabled) {
+  background: var(--muted);
+  color: var(--card-foreground);
+  border-color: var(--primary);
+}
+
+/* ===== 追加ボタン ===== */
+.search-section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.add-task-button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border: 2px solid var(--primary);
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-family: "Cinzel", "Georgia", serif;
+}
+
+.add-task-button:hover {
+  background: var(--secondary);
+  border-color: var(--secondary);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(139, 69, 19, 0.3);
+}
+
+/* レスポンシブ対応 */
+@media (max-width: 768px) {
+  .modal-content {
+    margin: 1rem;
+    max-height: calc(100vh - 2rem);
+  }
+
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+
+  .form-actions {
+    flex-direction: column-reverse;
+  }
+
+  .form-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .search-section {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .add-task-button {
+    justify-content: center;
+  }
+}
+/* datetime-localのクリック領域を拡大 */
+.datetime-input {
+  cursor: pointer;
+  position: relative;
+}
+
+.datetime-input::-webkit-calendar-picker-indicator {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: auto;
+  height: auto;
+  cursor: pointer;
+  opacity: 0;
+}
+
+/* 右端にシンプルなカレンダーアイコンを表示 */
+.datetime-input::after {
+  content: "";
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--primary);
+  border-radius: 2px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    transparent 25%,
+    var(--primary) 25%,
+    var(--primary) 35%,
+    transparent 35%,
+    transparent 65%,
+    var(--primary) 65%,
+    var(--primary) 75%,
+    transparent 75%
+  );
+}
+
+/* カレンダーの上部（日付部分）を表現 */
+.datetime-input::before {
+  content: "";
+  position: absolute;
+  right: 0.9rem;
+  top: calc(50% - 6px);
+  pointer-events: none;
+  width: 4px;
+  height: 4px;
+  background: var(--primary);
+  border-radius: 1px;
+}
+/* プレースホルダーの色を黒に変更 */
+.form-input::placeholder,
+.form-textarea::placeholder {
+  color: #000000;
+  opacity: 0.7;
+}
+
+/* ダークモードでも黒を維持 */
+@media (prefers-color-scheme: dark) {
+  .form-input::placeholder,
+  .form-textarea::placeholder {
+    color: #000000;
+    opacity: 0.7;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1368,3 +1368,11 @@ body {
     opacity: 0.7;
   }
 }
+.status-cancelled {
+  background: #979797;
+  color: white;
+}
+
+.stat-cancelled .stat-number {
+  color: #979797;
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Toaster } from "react-hot-toast";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -15,6 +16,19 @@ export default function RootLayout({
     <html lang="ja" suppressHydrationWarning>
       <body suppressHydrationWarning>
         {children}
+        <Toaster
+          position="top-right"
+          toastOptions={{
+            duration: 6000,
+            style: {
+              background: "var(--card)",
+              color: "var(--card-foreground)",
+              border: "1px solid var(--border)",
+              fontSize: "12px",
+              fontWeight: "500",
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Modal = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  className,
+}: ModalProps) => {
+  // ESCキーでモーダルを閉じる
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      // モーダル表示時はスクロールを無効化
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className={cn("modal-content", className)}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* モーダルヘッダー */}
+        <div className="modal-header">
+          <h2 className="modal-title">{title}</h2>
+          <button
+            onClick={onClose}
+            className="modal-close-button"
+            aria-label="モーダルを閉じる"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* モーダルボディ */}
+        <div className="modal-body">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/TaskControls.tsx
+++ b/frontend/src/components/TaskControls.tsx
@@ -2,7 +2,7 @@ import { Filter, SortAsc, SortDesc } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type SortOption = "priority" | "deadline" | "duration" | "created_at";
-type FilterOption = "all" | "todo" | "in_progress" | "done";
+type FilterOption = "all" | "todo" | "in_progress" | "completed" | "cancelled";
 
 interface TaskControlsProps {
   filterBy: FilterOption;
@@ -35,7 +35,8 @@ export const TaskControls = ({
               { key: "all", label: "全て" },
               { key: "todo", label: "未着手" },
               { key: "in_progress", label: "進行中" },
-              { key: "done", label: "完了" },
+              { key: "completed", label: "完了" },
+              { key: "cancelled", label: "キャンセル" },
             ] as { key: FilterOption; label: string }[]
           ).map(({ key, label }) => (
             <button

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -158,11 +158,11 @@ export const TaskForm = ({
             )}
             disabled={isLoading}
           >
-            {[1, 2, 3, 4, 5].map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
-            ))}
+            <option value={1}>1 (とても低い)</option>
+            <option value={2}>2 (低い)</option>
+            <option value={3}>3 (普通)</option>
+            <option value={4}>4 (高い)</option>
+            <option value={5}>5 (とても高い)</option>
           </select>
         </FormField>
 
@@ -182,11 +182,11 @@ export const TaskForm = ({
             className={cn("form-select", errors.urgency && "form-input-error")}
             disabled={isLoading}
           >
-            {[1, 2, 3, 4, 5].map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
-            ))}
+            <option value={1}>1 (とても低い)</option>
+            <option value={2}>2 (低い)</option>
+            <option value={3}>3 (普通)</option>
+            <option value={4}>4 (高い)</option>
+            <option value={5}>5 (とても高い)</option>
           </select>
         </FormField>
       </FormRow>
@@ -232,11 +232,16 @@ export const TaskForm = ({
             )}
             disabled={isLoading}
           >
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
-              <option key={value} value={value}>
-                {value}
-              </option>
-            ))}
+            <option value={1}>1 (とても少ない)</option>
+            <option value={2}>2 (少ない)</option>
+            <option value={3}>3 (やや少ない)</option>
+            <option value={4}>4 (普通)</option>
+            <option value={5}>5 (やや多い)</option>
+            <option value={6}>6 (多い)</option>
+            <option value={7}>7 (かなり多い)</option>
+            <option value={8}>8 (とても多い)</option>
+            <option value={9}>9 (非常に多い)</option>
+            <option value={10}>10 (最大)</option>
           </select>
         </FormField>
       </FormRow>
@@ -244,7 +249,7 @@ export const TaskForm = ({
       {/* 難易度・ステータス */}
       <FormRow>
         <FormField
-          label="難易度"
+          label="難易度（取り組みやすさ）"
           htmlFor="ease"
           required
           error={errors.ease}

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -34,7 +34,7 @@ export interface TaskFormData {
   ease: number;
   deadline?: string;
   dependencies: number[];
-  status: "todo" | "in_progress" | "done";
+  status: "todo" | "in_progress" | "completed" | "cancelled";
 }
 
 export const TaskForm = ({
@@ -271,7 +271,11 @@ export const TaskForm = ({
             onChange={(e) =>
               handleInputChange(
                 "status",
-                e.target.value as "todo" | "in_progress" | "done"
+                e.target.value as
+                  | "todo"
+                  | "in_progress"
+                  | "completed"
+                  | "cancelled"
               )
             }
             className="form-select"
@@ -279,7 +283,8 @@ export const TaskForm = ({
           >
             <option value="todo">未着手</option>
             <option value="in_progress">進行中</option>
-            <option value="done">完了</option>
+            <option value="completed">完了</option>
+            <option value="cancelled">キャンセル</option>
           </select>
         </FormField>
       </FormRow>

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Task } from "@/types/task";
+import {
+  Save,
+  X,
+  Target,
+  AlertTriangle,
+  Clock,
+  Zap,
+  Shield,
+  Calendar,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useTaskFormValidation } from "@/hooks/useTaskFormValidation";
+import { FormField } from "@/components/form/FormField";
+import { FormRow } from "@/components/form/FormRow";
+
+interface TaskFormProps {
+  task?: Task | null;
+  onSubmit: (taskData: TaskFormData) => Promise<void>;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export interface TaskFormData {
+  title: string;
+  description?: string;
+  importance: number;
+  urgency: number;
+  duration: number;
+  energy_required: number;
+  ease: number;
+  deadline?: string;
+  dependencies: number[];
+  status: "todo" | "in_progress" | "done";
+}
+
+export const TaskForm = ({
+  task,
+  onSubmit,
+  onCancel,
+  isLoading = false,
+}: TaskFormProps) => {
+  const [formData, setFormData] = useState<TaskFormData>({
+    title: "",
+    description: "",
+    importance: 3,
+    urgency: 3,
+    duration: 60,
+    energy_required: 5,
+    ease: 3,
+    deadline: "",
+    dependencies: [],
+    status: "todo",
+  });
+
+  const { errors, validateForm, clearError } = useTaskFormValidation();
+
+  // 編集モードの場合、既存データを設定
+  useEffect(() => {
+    if (task) {
+      setFormData({
+        title: task.title,
+        description: task.description || "",
+        importance: task.importance,
+        urgency: task.urgency,
+        duration: task.duration,
+        energy_required: task.energy_required,
+        ease: task.ease,
+        deadline: task.deadline
+          ? new Date(task.deadline).toISOString().slice(0, 16)
+          : "",
+        dependencies: task.dependencies,
+        status: task.status,
+      });
+    }
+  }, [task]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm(formData)) {
+      return;
+    }
+
+    try {
+      await onSubmit(formData);
+    } catch (error) {
+      console.error("フォーム送信エラー:", error);
+    }
+  };
+
+  const handleInputChange = (
+    field: keyof TaskFormData,
+    value: string | number | number[]
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+    // エラーをクリア
+    clearError(field);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="task-form">
+      {/* タイトル */}
+      <FormField
+        label="タスクタイトル"
+        htmlFor="title"
+        required
+        error={errors.title}
+      >
+        <input
+          id="title"
+          type="text"
+          value={formData.title}
+          onChange={(e) => handleInputChange("title", e.target.value)}
+          className={cn("form-input", errors.title && "form-input-error")}
+          placeholder="タスクのタイトルを入力"
+          disabled={isLoading}
+        />
+      </FormField>
+
+      {/* 説明 */}
+      <FormField label="説明" htmlFor="description">
+        <textarea
+          id="description"
+          value={formData.description}
+          onChange={(e) => handleInputChange("description", e.target.value)}
+          className="form-textarea"
+          placeholder="タスクの説明を入力"
+          rows={3}
+          disabled={isLoading}
+        />
+      </FormField>
+
+      {/* 重要度・緊急度 */}
+      <FormRow>
+        <FormField
+          label="重要度"
+          htmlFor="importance"
+          required
+          error={errors.importance}
+          icon={<Target className="w-4 h-4" />}
+        >
+          <select
+            id="importance"
+            value={formData.importance}
+            onChange={(e) =>
+              handleInputChange("importance", parseInt(e.target.value))
+            }
+            className={cn(
+              "form-select",
+              errors.importance && "form-input-error"
+            )}
+            disabled={isLoading}
+          >
+            {[1, 2, 3, 4, 5].map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </FormField>
+
+        <FormField
+          label="緊急度"
+          htmlFor="urgency"
+          required
+          error={errors.urgency}
+          icon={<AlertTriangle className="w-4 h-4" />}
+        >
+          <select
+            id="urgency"
+            value={formData.urgency}
+            onChange={(e) =>
+              handleInputChange("urgency", parseInt(e.target.value))
+            }
+            className={cn("form-select", errors.urgency && "form-input-error")}
+            disabled={isLoading}
+          >
+            {[1, 2, 3, 4, 5].map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </FormField>
+      </FormRow>
+
+      {/* 所要時間・エネルギー */}
+      <FormRow>
+        <FormField
+          label="所要時間（分）"
+          htmlFor="duration"
+          required
+          error={errors.duration}
+          icon={<Clock className="w-4 h-4" />}
+        >
+          <input
+            id="duration"
+            type="number"
+            min="1"
+            value={formData.duration}
+            onChange={(e) =>
+              handleInputChange("duration", parseInt(e.target.value) || 0)
+            }
+            className={cn("form-input", errors.duration && "form-input-error")}
+            disabled={isLoading}
+          />
+        </FormField>
+
+        <FormField
+          label="エネルギー"
+          htmlFor="energy_required"
+          required
+          error={errors.energy_required}
+          icon={<Zap className="w-4 h-4" />}
+        >
+          <select
+            id="energy_required"
+            value={formData.energy_required}
+            onChange={(e) =>
+              handleInputChange("energy_required", parseInt(e.target.value))
+            }
+            className={cn(
+              "form-select",
+              errors.energy_required && "form-input-error"
+            )}
+            disabled={isLoading}
+          >
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((value) => (
+              <option key={value} value={value}>
+                {value}
+              </option>
+            ))}
+          </select>
+        </FormField>
+      </FormRow>
+
+      {/* 難易度・ステータス */}
+      <FormRow>
+        <FormField
+          label="難易度"
+          htmlFor="ease"
+          required
+          error={errors.ease}
+          icon={<Shield className="w-4 h-4" />}
+        >
+          <select
+            id="ease"
+            value={formData.ease}
+            onChange={(e) =>
+              handleInputChange("ease", parseInt(e.target.value))
+            }
+            className={cn("form-select", errors.ease && "form-input-error")}
+            disabled={isLoading}
+          >
+            <option value={1}>1 (とても難しい)</option>
+            <option value={2}>2 (難しい)</option>
+            <option value={3}>3 (普通)</option>
+            <option value={4}>4 (簡単)</option>
+            <option value={5}>5 (とても簡単)</option>
+          </select>
+        </FormField>
+
+        <FormField label="ステータス" htmlFor="status">
+          <select
+            id="status"
+            value={formData.status}
+            onChange={(e) =>
+              handleInputChange(
+                "status",
+                e.target.value as "todo" | "in_progress" | "done"
+              )
+            }
+            className="form-select"
+            disabled={isLoading}
+          >
+            <option value="todo">未着手</option>
+            <option value="in_progress">進行中</option>
+            <option value="done">完了</option>
+          </select>
+        </FormField>
+      </FormRow>
+
+      {/* 期限 */}
+      <FormField
+        label="期限"
+        htmlFor="deadline"
+        icon={<Calendar className="w-4 h-4" />}
+      >
+        <input
+          id="deadline"
+          type="datetime-local"
+          value={formData.deadline}
+          onChange={(e) => handleInputChange("deadline", e.target.value)}
+          className="form-input datetime-input"
+          disabled={isLoading}
+        />
+      </FormField>
+
+      {/* フォームボタン */}
+      <div className="form-actions">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="form-button form-button-secondary"
+          disabled={isLoading}
+        >
+          <X className="w-4 h-4" />
+          キャンセル
+        </button>
+        <button
+          type="submit"
+          className="form-button form-button-primary"
+          disabled={isLoading}
+        >
+          <Save className="w-4 h-4" />
+          {isLoading ? "保存中..." : task ? "更新" : "作成"}
+        </button>
+      </div>
+    </form>
+  );
+};

--- a/frontend/src/components/TaskForm.tsx
+++ b/frontend/src/components/TaskForm.tsx
@@ -122,13 +122,16 @@ export const TaskForm = ({
       </FormField>
 
       {/* 説明 */}
-      <FormField label="説明" htmlFor="description">
+      <FormField label="説明" htmlFor="description" error={errors.description}>
         <textarea
           id="description"
           value={formData.description}
           onChange={(e) => handleInputChange("description", e.target.value)}
-          className="form-textarea"
-          placeholder="タスクの説明を入力"
+          className={cn(
+            "form-textarea",
+            errors.description && "form-input-error"
+          )}
+          placeholder="タスクの説明を入力（200文字以内）"
           rows={3}
           disabled={isLoading}
         />

--- a/frontend/src/components/TaskGrid.tsx
+++ b/frontend/src/components/TaskGrid.tsx
@@ -6,9 +6,17 @@ interface TaskGridProps {
   tasks: Task[];
   searchTerm: string;
   filterBy: string;
+  onEditTask: (task: Task) => void;
+  onDeleteTask: (taskId: number) => void;
 }
 
-export const TaskGrid = ({ tasks, searchTerm, filterBy }: TaskGridProps) => {
+export const TaskGrid = ({
+  tasks,
+  searchTerm,
+  filterBy,
+  onEditTask,
+  onDeleteTask,
+}: TaskGridProps) => {
   if (tasks.length === 0) {
     return (
       <div className="empty-task-board">
@@ -35,7 +43,12 @@ export const TaskGrid = ({ tasks, searchTerm, filterBy }: TaskGridProps) => {
     <div className="task-grid-container">
       <div className="task-cards-grid">
         {tasks.map((task) => (
-          <TaskCard key={task.id} task={task} />
+          <TaskCard
+            key={task.id}
+            task={task}
+            onEdit={onEditTask}
+            onDelete={onDeleteTask}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import { useState } from "react";
 import { useTasks } from "@/hooks/useTasks";
 import { useTaskFilters } from "@/hooks/useTaskFilters";
 import { TaskStats } from "./TaskStats";
@@ -14,7 +14,7 @@ import { taskApi } from "@/lib/api";
 import { Task } from "@/types/task";
 
 type SortOption = "priority" | "deadline" | "duration" | "created_at";
-type FilterOption = "all" | "todo" | "in_progress" | "done";
+type FilterOption = "all" | "todo" | "in_progress" | "completed" | "cancelled";
 
 export const TaskList = () => {
   const [searchTerm, setSearchTerm] = useState("");

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -65,12 +65,26 @@ export const TaskList = () => {
   const handleSubmitTask = async (taskData: TaskFormData) => {
     setIsSubmitting(true);
     try {
+      // TaskFormDataをTask型に変換
+      const taskPayload = {
+        title: taskData.title,
+        description: taskData.description || "",
+        importance: taskData.importance,
+        urgency: taskData.urgency,
+        duration: taskData.duration,
+        energy_required: taskData.energy_required,
+        ease: taskData.ease,
+        deadline: taskData.deadline || undefined,
+        dependencies: taskData.dependencies,
+        status: taskData.status,
+      };
+
       if (editingTask) {
-        // 編集モード
-        await taskApi.updateTask(editingTask.id, taskData);
+        // 編集
+        await taskApi.updateTask(editingTask.id, taskPayload);
       } else {
-        // 新規作成モード
-        await taskApi.createTask(taskData);
+        // 新規作成
+        await taskApi.createTask(taskPayload);
       }
 
       // タスク一覧を再取得

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -8,6 +8,10 @@ import { TaskSearch } from "./TaskSearch";
 import { TaskControls } from "./TaskControls";
 import { TaskGrid } from "./TaskGrid";
 import { LoadingState, ErrorState } from "./TaskLoadingStates";
+import { Modal } from "./Modal";
+import { TaskForm, TaskFormData } from "./TaskForm";
+import { taskApi } from "@/lib/api";
+import { Task } from "@/types/task";
 
 type SortOption = "priority" | "deadline" | "duration" | "created_at";
 type FilterOption = "all" | "todo" | "in_progress" | "done";
@@ -17,6 +21,11 @@ export const TaskList = () => {
   const [sortBy, setSortBy] = useState<SortOption>("priority");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [filterBy, setFilterBy] = useState<FilterOption>("all");
+
+  // モーダル状態
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   // カスタムフックを使用
   const { tasks, loading, error, mounted, refetch } = useTasks();
@@ -34,6 +43,59 @@ export const TaskList = () => {
 
   const handleSortOrderToggle = () => {
     setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+  };
+
+  // モーダル関連の処理
+  const handleAddTask = () => {
+    setEditingTask(null);
+    setIsModalOpen(true);
+  };
+
+  const handleEditTask = (task: Task) => {
+    setEditingTask(task);
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setEditingTask(null);
+    setIsSubmitting(false);
+  };
+
+  const handleSubmitTask = async (taskData: TaskFormData) => {
+    setIsSubmitting(true);
+    try {
+      if (editingTask) {
+        // 編集モード
+        await taskApi.updateTask(editingTask.id, taskData);
+      } else {
+        // 新規作成モード
+        await taskApi.createTask(taskData);
+      }
+
+      // タスク一覧を再取得
+      await refetch();
+      handleCloseModal();
+    } catch (error) {
+      console.error("タスクの保存に失敗しました:", error);
+      // エラーハンドリング（必要に応じてトースト通知など）
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDeleteTask = async (taskId: number) => {
+    if (!confirm("このタスクを削除しますか？")) {
+      return;
+    }
+
+    try {
+      await taskApi.deleteTask(taskId);
+      await refetch();
+    } catch (error) {
+      console.error("タスクの削除に失敗しました:", error);
+      // エラーハンドリング（必要に応じてトースト通知など）
+    }
   };
 
   // クライアントサイドでマウントされるまで何も表示しない
@@ -54,7 +116,11 @@ export const TaskList = () => {
       <TaskStats stats={stats} />
 
       <div className="task-controls">
-        <TaskSearch searchTerm={searchTerm} onSearchChange={setSearchTerm} />
+        <TaskSearch
+          searchTerm={searchTerm}
+          onSearchChange={setSearchTerm}
+          onAddTask={handleAddTask}
+        />
         <TaskControls
           filterBy={filterBy}
           sortBy={sortBy}
@@ -69,7 +135,23 @@ export const TaskList = () => {
         tasks={filteredAndSortedTasks}
         searchTerm={searchTerm}
         filterBy={filterBy}
+        onEditTask={handleEditTask}
+        onDeleteTask={handleDeleteTask}
       />
+
+      {/* タスクフォームモーダル */}
+      <Modal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        title={editingTask ? "タスクを編集" : "新しいタスクを追加"}
+      >
+        <TaskForm
+          task={editingTask}
+          onSubmit={handleSubmitTask}
+          onCancel={handleCloseModal}
+          isLoading={isSubmitting}
+        />
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/components/TaskList.tsx
+++ b/frontend/src/components/TaskList.tsx
@@ -12,6 +12,7 @@ import { Modal } from "./Modal";
 import { TaskForm, TaskFormData } from "./TaskForm";
 import { taskApi } from "@/lib/api";
 import { Task } from "@/types/task";
+import toast from "react-hot-toast";
 
 type SortOption = "priority" | "deadline" | "duration" | "created_at";
 type FilterOption = "all" | "todo" | "in_progress" | "completed" | "cancelled";
@@ -90,9 +91,19 @@ export const TaskList = () => {
       // タスク一覧を再取得
       await refetch();
       handleCloseModal();
+
+      // 成功トースト
+      toast.success(
+        editingTask ? "タスクを更新しました" : "タスクを作成しました"
+      );
     } catch (error) {
       console.error("タスクの保存に失敗しました:", error);
-      // エラーハンドリング（必要に応じてトースト通知など）
+      // エラートースト
+      toast.error(
+        `タスクの保存に失敗しました: ${
+          error instanceof Error ? error.message : "不明なエラー"
+        }`
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -106,9 +117,14 @@ export const TaskList = () => {
     try {
       await taskApi.deleteTask(taskId);
       await refetch();
+      toast.success("タスクを削除しました");
     } catch (error) {
       console.error("タスクの削除に失敗しました:", error);
-      // エラーハンドリング（必要に応じてトースト通知など）
+      toast.error(
+        `タスクの削除に失敗しました: ${
+          error instanceof Error ? error.message : "不明なエラー"
+        }`
+      );
     }
   };
 

--- a/frontend/src/components/TaskSearch.tsx
+++ b/frontend/src/components/TaskSearch.tsx
@@ -1,11 +1,16 @@
-import { Search } from "lucide-react";
+import { Search, Plus } from "lucide-react";
 
 interface TaskSearchProps {
   searchTerm: string;
   onSearchChange: (term: string) => void;
+  onAddTask: () => void;
 }
 
-export const TaskSearch = ({ searchTerm, onSearchChange }: TaskSearchProps) => {
+export const TaskSearch = ({
+  searchTerm,
+  onSearchChange,
+  onAddTask,
+}: TaskSearchProps) => {
   return (
     <div className="search-section">
       <div className="search-container">
@@ -18,6 +23,14 @@ export const TaskSearch = ({ searchTerm, onSearchChange }: TaskSearchProps) => {
           className="search-input"
         />
       </div>
+      <button
+        onClick={onAddTask}
+        className="add-task-button"
+        title="新しいタスクを追加"
+      >
+        <Plus className="w-4 h-4" />
+        追加
+      </button>
     </div>
   );
 };

--- a/frontend/src/components/TaskStats.tsx
+++ b/frontend/src/components/TaskStats.tsx
@@ -3,7 +3,8 @@ interface TaskStatsProps {
     total: number;
     todo: number;
     inProgress: number;
-    done: number;
+    completed: number;
+    cancelled: number;
     overdue: number;
     low: number;
     medium: number;
@@ -34,7 +35,11 @@ export const TaskStats = ({ stats }: TaskStatsProps) => {
         </div>
         <div className="stat-card stat-completed">
           <div className="stat-label">完了</div>
-          <div className="stat-number">{stats.done}</div>
+          <div className="stat-number">{stats.completed}</div>
+        </div>
+        <div className="stat-card stat-cancelled">
+          <div className="stat-label">キャンセル</div>
+          <div className="stat-number">{stats.cancelled}</div>
         </div>
         <div className="stat-card stat-overdue">
           <div className="stat-label">期限切れ</div>
@@ -43,7 +48,7 @@ export const TaskStats = ({ stats }: TaskStatsProps) => {
         <div className="stat-card stat-completion">
           <div className="stat-label">完了率</div>
           <div className="stat-number">
-            {Math.round((stats.done / stats.total) * 100) || 0}%
+            {Math.round((stats.completed / stats.total) * 100) || 0}%
           </div>
         </div>
       </div>

--- a/frontend/src/components/form/FormField.tsx
+++ b/frontend/src/components/form/FormField.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface FormFieldProps {
+  label: string;
+  htmlFor: string;
+  required?: boolean;
+  error?: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const FormField = ({
+  label,
+  htmlFor,
+  required = false,
+  error,
+  icon,
+  children,
+}: FormFieldProps) => {
+  return (
+    <div className="form-group">
+      <label
+        htmlFor={htmlFor}
+        className={cn("form-label", required && "required")}
+      >
+        {icon}
+        {label}
+      </label>
+      {children}
+      {error && <span className="form-error">{error}</span>}
+    </div>
+  );
+};

--- a/frontend/src/components/form/FormRow.tsx
+++ b/frontend/src/components/form/FormRow.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+interface FormRowProps {
+  children: React.ReactNode;
+}
+
+export const FormRow = ({ children }: FormRowProps) => {
+  return <div className="form-row">{children}</div>;
+};

--- a/frontend/src/hooks/useTaskFilters.ts
+++ b/frontend/src/hooks/useTaskFilters.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { Task } from "@/types/task";
 
 type SortOption = "priority" | "deadline" | "duration" | "title" | "created_at";
-type FilterOption = "all" | "todo" | "in_progress" | "done";
+type FilterOption = "all" | "todo" | "in_progress" | "completed" | "cancelled";
 
 interface UseTaskFiltersProps {
   tasks: Task[];
@@ -80,7 +80,8 @@ export const useTaskFilters = ({
     const total = tasks.length;
     const todo = tasks.filter((t) => t.status === "todo").length;
     const inProgress = tasks.filter((t) => t.status === "in_progress").length;
-    const done = tasks.filter((t) => t.status === "done").length;
+    const completed = tasks.filter((t) => t.status === "completed").length;
+    const cancelled = tasks.filter((t) => t.status === "cancelled").length;
     const overdue = tasks.filter(
       (t) => t.deadline && new Date(t.deadline) < new Date()
     ).length;
@@ -99,7 +100,8 @@ export const useTaskFilters = ({
       total,
       todo,
       inProgress,
-      done,
+      completed,
+      cancelled,
       overdue,
       low,
       medium,

--- a/frontend/src/hooks/useTaskFormValidation.ts
+++ b/frontend/src/hooks/useTaskFormValidation.ts
@@ -22,7 +22,7 @@ export const useTaskFormValidation = () => {
       formData.importance < 1 ||
       formData.importance > 5
     ) {
-      newErrors.importance = "重要度は1-5の整数で入力してください";
+      newErrors.importance = "重要度は1-5の範囲で入力してください";
     }
 
     if (
@@ -30,11 +30,11 @@ export const useTaskFormValidation = () => {
       formData.urgency < 1 ||
       formData.urgency > 5
     ) {
-      newErrors.urgency = "緊急度は1-5の整数で入力してください";
+      newErrors.urgency = "緊急度は1-5の範囲で入力してください";
     }
 
-    if (!Number.isInteger(formData.duration) || formData.duration < 1) {
-      newErrors.duration = "所要時間は1以上の整数で入力してください";
+    if (!formData.duration || formData.duration <= 0) {
+      newErrors.duration = "所要時間は1以上で入力してください";
     }
 
     if (
@@ -42,7 +42,7 @@ export const useTaskFormValidation = () => {
       formData.energy_required < 1 ||
       formData.energy_required > 10
     ) {
-      newErrors.energy_required = "エネルギーは1-10の整数で入力してください";
+      newErrors.energy_required = "エネルギーは1-10の範囲で入力してください";
     }
 
     if (
@@ -50,7 +50,7 @@ export const useTaskFormValidation = () => {
       formData.ease < 1 ||
       formData.ease > 5
     ) {
-      newErrors.ease = "難易度は1-5の整数で入力してください";
+      newErrors.ease = "難易度は1-5の範囲で入力してください";
     }
 
     setErrors(newErrors);

--- a/frontend/src/hooks/useTaskFormValidation.ts
+++ b/frontend/src/hooks/useTaskFormValidation.ts
@@ -16,6 +16,11 @@ export const useTaskFormValidation = () => {
       newErrors.title = "タイトルは必須です";
     }
 
+    // 説明文字数チェック
+    if (formData.description && formData.description.length > 200) {
+      newErrors.description = "説明は200文字以内で入力してください";
+    }
+
     // 整数値チェック
     if (
       !Number.isInteger(formData.importance) ||

--- a/frontend/src/hooks/useTaskFormValidation.ts
+++ b/frontend/src/hooks/useTaskFormValidation.ts
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { TaskFormData } from "@/components/TaskForm";
+
+interface ValidationErrors {
+  [key: string]: string;
+}
+
+export const useTaskFormValidation = () => {
+  const [errors, setErrors] = useState<ValidationErrors>({});
+
+  const validateForm = (formData: TaskFormData): boolean => {
+    const newErrors: ValidationErrors = {};
+
+    // タイトル必須チェック
+    if (!formData.title.trim()) {
+      newErrors.title = "タイトルは必須です";
+    }
+
+    // 整数値チェック
+    if (
+      !Number.isInteger(formData.importance) ||
+      formData.importance < 1 ||
+      formData.importance > 5
+    ) {
+      newErrors.importance = "重要度は1-5の整数で入力してください";
+    }
+
+    if (
+      !Number.isInteger(formData.urgency) ||
+      formData.urgency < 1 ||
+      formData.urgency > 5
+    ) {
+      newErrors.urgency = "緊急度は1-5の整数で入力してください";
+    }
+
+    if (!Number.isInteger(formData.duration) || formData.duration < 1) {
+      newErrors.duration = "所要時間は1以上の整数で入力してください";
+    }
+
+    if (
+      !Number.isInteger(formData.energy_required) ||
+      formData.energy_required < 1 ||
+      formData.energy_required > 10
+    ) {
+      newErrors.energy_required = "エネルギーは1-10の整数で入力してください";
+    }
+
+    if (
+      !Number.isInteger(formData.ease) ||
+      formData.ease < 1 ||
+      formData.ease > 5
+    ) {
+      newErrors.ease = "難易度は1-5の整数で入力してください";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const clearError = (field: string) => {
+    if (errors[field]) {
+      setErrors((prev) => ({ ...prev, [field]: "" }));
+    }
+  };
+
+  const clearAllErrors = () => {
+    setErrors({});
+  };
+
+  return {
+    errors,
+    validateForm,
+    clearError,
+    clearAllErrors,
+  };
+};

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -1,20 +1,20 @@
 export interface Task {
-  id: number
-  title: string
-  description?: string
-  deadline?: string
-  duration: number // 分単位
-  energy_required: number // 1-10
-  importance: number // 1-5
-  urgency: number // 1-5
-  ease: number // 1-5
-  status: 'todo' | 'in_progress' | 'done'
-  dependencies: number[]
-  created_at: string
-  updated_at: string
+  id: number;
+  title: string;
+  description?: string;
+  deadline?: string;
+  duration: number; // 分単位
+  energy_required: number; // 1-10
+  importance: number; // 1-5
+  urgency: number; // 1-5
+  ease: number; // 1-5
+  status: "todo" | "in_progress" | "completed" | "cancelled";
+  dependencies: number[];
+  created_at: string;
+  updated_at: string;
 }
 
 export interface TaskListResponse {
-  tasks: Task[]
-  total: number
+  tasks: Task[];
+  total: number;
 }

--- a/frontend/src/utils/taskUtils.ts
+++ b/frontend/src/utils/taskUtils.ts
@@ -87,7 +87,7 @@ export const formatDuration = (minutes: number): string => {
 // ステータス設定を取得
 export const getStatusConfig = (status: Task["status"]) => {
   switch (status) {
-    case "done":
+    case "completed":
       return {
         label: "完了",
         badgeClass: "status-badge status-completed",
@@ -96,6 +96,11 @@ export const getStatusConfig = (status: Task["status"]) => {
       return {
         label: "進行中",
         badgeClass: "status-badge status-active",
+      };
+    case "cancelled":
+      return {
+        label: "キャンセル",
+        badgeClass: "status-badge status-cancelled",
       };
     default:
       return {

--- a/frontend/src/utils/taskUtils.ts
+++ b/frontend/src/utils/taskUtils.ts
@@ -1,0 +1,106 @@
+import { Task } from "@/types/task";
+
+// 優先度ランクの型定義
+export interface PriorityRank {
+  rank: "low" | "medium" | "high" | "urgent";
+  name: string;
+  color: string;
+  cardClass: string;
+}
+
+// 難易度レベルの型定義
+export interface DifficultyLevel {
+  text: string;
+  level: "very-hard" | "hard" | "normal" | "easy" | "very-easy";
+}
+
+// 締切状態の型定義
+export type DeadlineStatus = "none" | "normal" | "urgent" | "overdue";
+
+// 優先度ランクを計算
+export const getPriorityRank = (
+  importance: number,
+  urgency: number
+): PriorityRank => {
+  const priorityScore = importance + urgency;
+
+  if (priorityScore <= 4) {
+    return {
+      rank: "low",
+      name: "低",
+      color: "priority-badge-low",
+      cardClass: "task-card priority-low",
+    };
+  }
+  if (priorityScore <= 6) {
+    return {
+      rank: "medium",
+      name: "中",
+      color: "priority-badge-medium",
+      cardClass: "task-card priority-medium",
+    };
+  }
+  if (priorityScore <= 8) {
+    return {
+      rank: "high",
+      name: "高",
+      color: "priority-badge-high",
+      cardClass: "task-card priority-high",
+    };
+  }
+  return {
+    rank: "urgent",
+    name: "緊急",
+    color: "priority-badge-urgent",
+    cardClass: "task-card priority-urgent",
+  };
+};
+
+// 難易度レベルを取得
+export const getDifficultyLevel = (ease: number): DifficultyLevel => {
+  if (ease === 5) return { text: "とても簡単", level: "very-easy" };
+  if (ease === 4) return { text: "簡単", level: "easy" };
+  if (ease === 3) return { text: "普通", level: "normal" };
+  if (ease === 2) return { text: "難しい", level: "hard" };
+  return { text: "とても難しい", level: "very-hard" };
+};
+
+// 締切状態を判定
+export const getDeadlineStatus = (deadline?: string): DeadlineStatus => {
+  if (!deadline) return "none";
+
+  const deadlineDate = new Date(deadline);
+  const now = new Date();
+  const threeDaysFromNow = new Date(now.getTime() + 3 * 24 * 60 * 60 * 1000);
+
+  if (deadlineDate < now) return "overdue";
+  if (deadlineDate < threeDaysFromNow) return "urgent";
+  return "normal";
+};
+
+// 所要時間をフォーマット
+export const formatDuration = (minutes: number): string => {
+  const hours = minutes / 60;
+  return `${hours.toFixed(2).replace(/\.?0+$/, "")}h`;
+};
+
+// ステータス設定を取得
+export const getStatusConfig = (status: Task["status"]) => {
+  switch (status) {
+    case "done":
+      return {
+        label: "完了",
+        badgeClass: "status-badge status-completed",
+      };
+    case "in_progress":
+      return {
+        label: "進行中",
+        badgeClass: "status-badge status-active",
+      };
+    default:
+      return {
+        label: "未着手",
+        badgeClass: "status-badge status-pending",
+      };
+  }
+};


### PR DESCRIPTION
## 概要
issue #7 に対応し、タスクの登録・編集フォーム機能をモーダル形式で実装した。

## 実装内容

### フロントエンド
- **TaskForm**: バリデーション機能付きタスクフォームコンポーネント
- **Modal**: ESCキー・オーバーレイクリック対応のモーダルコンポーネント
- **FormField/FormRow**: 再利用可能なフォーム部品コンポーネント
- **useTaskFormValidation**: フォームバリデーション用カスタムフック
- **API統合**: CRUD操作（作成・更新・削除）の実装
- **Toast通知**: 成功・エラー通知機能
- **レスポンシブ対応**: モバイル・タブレット・デスクトップ対応

### バックエンド
- **updateアクション**: タスク更新APIエンドポイントの追加
- **バリデーション**: descriptionフィールドに200文字制限を追加
- **RSpecテスト**: updateアクションのテストケース追加

### UI/UX改善
- **ステータス統一**: バックエンド（completed/cancelled）とフロントエンドの統一
- **フォーム項目**: 重要度・緊急度・エネルギー・難易度に説明コメント追加
- **エラー表示**: 各フィールドのバリデーションエラー表示
- **文字数制限**: 説明フィールドの200文字制限とエラー表示

## 技術的変更点

### 型定義の統一
- Task型のstatusを`done`から`completed`に変更
- `cancelled`ステータスの追加
- フィルター・統計機能の対応

### バリデーション強化
- フロントエンド・バックエンド両方でのバリデーション実装
- 説明フィールドの文字数制限（200文字以内）
- 数値フィールドの範囲チェック

### テスト追加
- updateアクションのRSpecテスト
- バリデーションテストケース
- 正常系・異常系・エラーハンドリングのテスト

## 動作確認
- タスクの新規作成
- タスクの編集・更新
- タスクの削除
- バリデーションエラーの表示
- モーダルの開閉操作
- レスポンシブ表示

Closes #7